### PR TITLE
Travis will not deploy without the use of PEM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ENV['git'] = {
 
 - Use [`ssh-keygen`](https://www.freebsd.org/cgi/man.cgi?query=ssh-keygen&sektion=1&manpath=OpenBSD+3.9) to generate a new public/private key pair:
   ```bash
-  ssh-keygen -t rsa -b 4096 -N '' -f deploy_key
+  ssh-keygen -m PEM -t rsa -b 4096 -C "your_email@example.com" -N '' -f deploy_key
   ```
 - This will produce two files in your current directory: `deploy_key` (the private key) and `deploy_key.pub` (the public key). **Do not commit these files to your repository.**
 - Configure the public key with your git hosting provider. For [Github](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys), you can find this under the settings for your repository, at `https://github.com/<user>/<repo>/settings/keys`


### PR DESCRIPTION
I spent a few hours before I searched the ember discord for similar issues, hopefully this helps someone else doing this not get stuck where I did.

# before

```sh
$ yarn install
481$ node_modules/.bin/ember deploy production
482Enter passphrase for /tmp/deploy_key_6923: 
```

# after

```sh
$ yarn install
$ node_modules/.bin/ember deploy production
479WARNING: Option "nodeWorker" is deprecated since workerpool@5.0.0. Please use "workerType" instead.
480building...
```